### PR TITLE
Lottie android 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ android/app/libs
 
 # Gitbook generated files
 _book
+
+# Yarn
+yarn-error.log

--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,17 @@
 
 buildscript {
   repositories {
+    google()
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.3.0'
   }
 }
 
 allprojects {
   repositories {
+    google()
     mavenLocal()
     jcenter()
     maven {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -98,7 +98,6 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId "com.airbnb.android"
@@ -145,11 +144,10 @@ android {
 }
 
 dependencies {
-    compile project(':lottie-react-native')
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:support-annotations:26.1.0'
-    compile "com.facebook.react:react-native:+"  // From node_modules
-
+    implementation project(':lottie-react-native')
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 
 // Run this once to be able to run the application with BUCK

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -137,6 +137,11 @@ android {
             }
         }
     }
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -97,7 +97,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.airbnb.android"
@@ -145,8 +145,7 @@ android {
 
 dependencies {
     implementation project(':lottie-react-native')
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -145,7 +145,6 @@ android {
 
 dependencies {
     implementation project(':lottie-react-native')
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example"
     android:versionCode="1"
     android:versionName="1.0">
@@ -6,16 +7,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="22" />
-
     <application
       android:name=".MainApplication"
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+        tools:ignore="AllowBackup,GoogleAppIndexingWarning">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "run:ios": "react-native run-ios --project-path ./example/ios",
     "start:android": "adb shell am start -n com.example/.MainActivity",
     "run:android": "./gradlew installDebug && npm run start:android",
-    "build:android": "./gradlew installDebug",
+    "build:android": "./gradlew assembleDebug",
     "lint": "eslint ./",
     "ci": "npm run lint",
     "publish:maven": "./gradlew clean check uploadArchives",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "run:ios": "react-native run-ios --project-path ./example/ios",
     "start:android": "adb shell am start -n com.example/.MainActivity",
     "run:android": "./gradlew installDebug && npm run start:android",
+    "build:android": "./gradlew installDebug",
     "lint": "eslint ./",
     "ci": "npm run lint",
     "publish:maven": "./gradlew clean check uploadArchives",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lottie-react-native",
+  "name": "@opengenius/lottie-react-native",
   "version": "3.0.0",
   "description": "React Native bindings for Lottie",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "2.6.1",
+  "version": "3.0.0",
   "description": "React Native bindings for Lottie",
   "main": "lib/index.js",
   "types": "src/js/index.d.ts",

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -26,6 +26,5 @@ android {
 
 dependencies {
   compileOnly "com.facebook.react:react-native:+"
-  implementation 'androidx.legacy:legacy-support-v4:1.0.0'
   implementation 'com.airbnb.android:lottie:3.0.0'
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,10 +5,8 @@ def safeExtGet(prop, fallback) {
 apply plugin: 'com.android.library'
 apply from: 'gradle-maven-push.gradle'
 
-def DEFAULT_ANDROID_SUPPORT_LIB_VERSION = "28.0.0"
-
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', 26)
+  compileSdkVersion safeExtGet('compileSdkVersion', 28)
   publishNonDefault true
 
   defaultConfig {
@@ -27,9 +25,7 @@ android {
 }
 
 dependencies {
-  def supportLibVersion = safeExtGet('supportLibVersion', DEFAULT_ANDROID_SUPPORT_LIB_VERSION)
-
   compileOnly "com.facebook.react:react-native:+"
-  implementation "com.android.support:appcompat-v7:$supportLibVersion"
+  implementation 'androidx.legacy:legacy-support-v4:1.0.0'
   implementation 'com.airbnb.android:lottie:3.0.0'
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,11 +5,10 @@ def safeExtGet(prop, fallback) {
 apply plugin: 'com.android.library'
 apply from: 'gradle-maven-push.gradle'
 
-def DEFAULT_ANDROID_SUPPORT_LIB_VERSION = "27.0.2"
+def DEFAULT_ANDROID_SUPPORT_LIB_VERSION = "28.0.0"
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 26)
-  buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
   publishNonDefault true
 
   defaultConfig {
@@ -32,5 +31,5 @@ dependencies {
 
   compileOnly "com.facebook.react:react-native:+"
   implementation "com.android.support:appcompat-v7:$supportLibVersion"
-  implementation 'com.airbnb.android:lottie:2.5.6'
+  implementation 'com.airbnb.android:lottie:3.0.0'
 }

--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -16,3 +16,6 @@ POM_DEVELOPER_NAME=Leland Richardson
 POM_NAME=Lottie React Native
 POM_ARTIFACT_ID=lottie-react-native
 POM_PACKAGING=aar
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -16,6 +16,3 @@ POM_DEVELOPER_NAME=Leland Richardson
 POM_NAME=Lottie React Native
 POM_ARTIFACT_ID=lottie-react-native
 POM_PACKAGING=aar
-
-android.useAndroidX=true
-android.enableJetifier=true

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.v4.view.ViewCompat;
+import androidx.core.view.ViewCompat;
 import android.widget.ImageView;
 import android.view.View.OnAttachStateChangeListener;
 import android.view.View;

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -162,30 +162,6 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setAnimationJson(json);
   }
 
-  /**
-   *
-   * @param view
-   * @param name
-   */
-  @ReactProp(name = "cacheStrategy")
-  public void setCacheStrategy(LottieAnimationView view, String name) {
-    if (name != null) {
-      LottieAnimationView.CacheStrategy strategy = LottieAnimationView.DEFAULT_CACHE_STRATEGY;
-      switch (name) {
-        case "none":
-          strategy = LottieAnimationView.CacheStrategy.None;
-          break;
-        case "weak":
-           strategy = LottieAnimationView.CacheStrategy.Weak;
-           break;
-        case "strong":
-          strategy = LottieAnimationView.CacheStrategy.Strong;
-          break;
-      }
-      getOrCreatePropertyManager(view).setCacheStrategy(strategy);
-    }
-  }
-
   @ReactProp(name = "resizeMode")
   public void setResizeMode(LottieAnimationView view, String resizeMode) {
     ImageView.ScaleType mode = null;

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -214,11 +214,6 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setLoop(loop);
   }
 
-  @ReactProp(name = "hardwareAccelerationAndroid")
-  public void setHardwareAcceleration(LottieAnimationView view, boolean use) {
-    getOrCreatePropertyManager(view).setUseHardwareAcceleration(use);
-  }
-
   @ReactProp(name = "imageAssetsFolder")
   public void setImageAssetsFolder(LottieAnimationView view, String imageAssetsFolder) {
     getOrCreatePropertyManager(view).setImageAssetsFolder(imageAssetsFolder);

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.os.Handler;
 import android.os.Looper;
-import androidx.core.view.ViewCompat;
 import android.widget.ImageView;
 import android.view.View.OnAttachStateChangeListener;
 import android.view.View;
@@ -115,7 +114,7 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
             if (startFrame != -1 && endFrame != -1) {
               view.setMinAndMaxFrame(args.getInt(0), args.getInt(1));
             }
-            if (ViewCompat.isAttachedToWindow(view)) {
+            if (view.isAttachedToWindow()) {
               view.setProgress(0f);
               view.playAnimation();
             } else {
@@ -141,7 +140,7 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
       case COMMAND_RESET: {
         new Handler(Looper.getMainLooper()).post(new Runnable() {
           @Override public void run() {
-            if (ViewCompat.isAttachedToWindow(view)) {
+            if (view.isAttachedToWindow()) {
               view.cancelAnimation();
               view.setProgress(0f);
             }

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -33,7 +33,6 @@ public class LottieAnimationViewPropertyManager {
   private boolean animationNameDirty;
 
   private String animationName;
-  private LottieAnimationView.CacheStrategy cacheStrategy;
   private ImageView.ScaleType scaleType;
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
@@ -49,11 +48,6 @@ public class LottieAnimationViewPropertyManager {
 
   public void setAnimationJson(String json) {
     this.animationJson = json;
-  }
-
-  public void setCacheStrategy(LottieAnimationView.CacheStrategy strategy) {
-    this.cacheStrategy = strategy;
-    this.animationNameDirty = true;
   }
 
   public void setProgress(Float progress) {
@@ -101,7 +95,7 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (animationNameDirty) {
-      view.setAnimation(animationName, cacheStrategy);
+      view.setAnimation(animationName);
       animationNameDirty = false;
     }
 

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -34,7 +34,6 @@ public class LottieAnimationViewPropertyManager {
 
   private String animationName;
   private LottieAnimationView.CacheStrategy cacheStrategy;
-  private Boolean useHardwareAcceleration;
   private ImageView.ScaleType scaleType;
   private String imageAssetsFolder;
   private Boolean enableMergePaths;
@@ -67,10 +66,6 @@ public class LottieAnimationViewPropertyManager {
 
   public void setLoop(boolean loop) {
     this.loop = loop;
-  }
-
-  public void setUseHardwareAcceleration(boolean useHardwareAcceleration) {
-    this.useHardwareAcceleration = useHardwareAcceleration;
   }
 
   public void setScaleType(ImageView.ScaleType scaleType) {
@@ -123,11 +118,6 @@ public class LottieAnimationViewPropertyManager {
     if (speed != null) {
       view.setSpeed(speed);
       speed = null;
-    }
-
-    if (useHardwareAcceleration != null) {
-      view.useHardwareAcceleration(useHardwareAcceleration);
-      useHardwareAcceleration = null;
     }
 
     if (scaleType != null) {

--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -90,7 +90,7 @@ public class LottieAnimationViewPropertyManager {
     }
 
     if (animationJson != null) {
-      view.setAnimation(new JsonReader(new StringReader(animationJson)));
+      view.setAnimationFromJson(animationJson, Integer.toString(animationJson.hashCode()));
       animationJson = null;
     }
 

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -60,7 +60,6 @@ const propTypes = {
   autoSize: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-  hardwareAccelerationAndroid: PropTypes.bool,
   cacheStrategy: PropTypes.oneOf(['none', 'weak', 'strong']),
   onAnimationFinish: PropTypes.func,
 };

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -60,7 +60,6 @@ const propTypes = {
   autoSize: PropTypes.bool,
   enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-  cacheStrategy: PropTypes.oneOf(['none', 'weak', 'strong']),
   onAnimationFinish: PropTypes.func,
 };
 


### PR DESCRIPTION
https://github.com/react-native-community/lottie-react-native/pull/485 with androidx stripped out.

Requires `force 'com.airbnb.android:lottie:3.0.3-support'` in `android/build.gradle` because lottie >= 2.8 only supports androidx, but a one-off support-lib version was published as 3.0.3-support (see https://twitter.com/gpeal8/status/1132824596749537280)

> Gabriel Peal - @gpeal8
> If you still haven't been able to upgrade your app to androidx and are stuck on Lottie 2.x, I just published a one-off 3.0.3-support artifact that supports non-androidx apps.
> That being said, please try and update your apps to androidx or you will fall farther and farther behind in all of your dependencies.